### PR TITLE
Add Klarna hero section

### DIFF
--- a/assets/klarna-hero.js
+++ b/assets/klarna-hero.js
@@ -1,0 +1,37 @@
+// ===========================================
+// KLARNA HERO - JAVASCRIPT
+// Animazioni, parallax, intersection observer
+// ===========================================
+
+document.addEventListener('DOMContentLoaded', () => {
+  const hero = document.querySelector('[data-klarna-hero]');
+  if (!hero) return;
+
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  const animateElements = hero.querySelectorAll('.klarna-animate');
+
+  if (!reducedMotion) {
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+        }
+      });
+    }, { rootMargin: '0px 0px -50px 0px' });
+
+    animateElements.forEach(el => observer.observe(el));
+
+    if (hero.dataset.parallax === 'true') {
+      const phone = hero.querySelector('.klarna-phone-mockup');
+      if (phone) {
+        window.addEventListener('scroll', () => {
+          const offset = window.scrollY * 0.2;
+          phone.style.transform = `translateY(${offset}px)`;
+        });
+      }
+    }
+  } else {
+    animateElements.forEach(el => el.classList.add('visible'));
+  }
+});

--- a/assets/klarna-sections.css
+++ b/assets/klarna-sections.css
@@ -1,0 +1,121 @@
+/* ===========================================
+   KLARNA HERO - CSS SPECIFICO
+   File: assets/klarna-sections.css
+   Hero gradients, layout, phone mockup
+   =========================================== */
+
+.klarna-hero {
+  background: linear-gradient(135deg, var(--klarna-dark) 0%, #2D1B4E 100%);
+  color: var(--klarna-white);
+  padding-top: var(--section-padding-top, var(--space-3xl));
+  padding-bottom: var(--section-padding-bottom, var(--space-3xl));
+  position: relative;
+  overflow: hidden;
+}
+
+.klarna-hero-container {
+  max-width: var(--container-max);
+  margin: 0 auto;
+  padding: 0 var(--space-lg);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3xl);
+  align-items: center;
+}
+
+.klarna-hero-content h1 {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: var(--font-weight-extrabold);
+  line-height: 1.1;
+  margin-bottom: var(--space-lg);
+}
+
+.klarna-hero-text {
+  font-size: 1.125rem;
+  line-height: 1.6;
+  margin-bottom: var(--space-xl);
+  opacity: 0.9;
+}
+
+.klarna-app-rating {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  font-size: 0.875rem;
+}
+
+.klarna-stars { color: #FCD34D; }
+
+.klarna-cta-btn {
+  background: var(--klarna-white);
+  color: var(--klarna-black);
+  padding: var(--space-md) var(--space-xl);
+  border-radius: var(--radius-xl);
+  text-decoration: none;
+  font-weight: var(--font-weight-semibold);
+  display: inline-block;
+  transition: all var(--duration-200) var(--ease-out);
+}
+
+.klarna-cta-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0,0,0,0.2);
+}
+
+.klarna-hero-phone {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.klarna-phone-mockup {
+  width: 280px;
+  height: 500px;
+  background: linear-gradient(135deg, #374151 0%, #1F2937 100%);
+  border-radius: var(--radius-2xl);
+  border: 3px solid #4B5563;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+  will-change: transform;
+}
+
+.klarna-phone-screen {
+  width: 90%;
+  height: 85%;
+  background: var(--klarna-black);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--klarna-white);
+  font-size: 0.875rem;
+}
+
+.klarna-animate {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity var(--duration-500) var(--ease-out), transform var(--duration-500) var(--ease-out);
+}
+
+.klarna-animate.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 768px) {
+  .klarna-hero-container {
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+    text-align: center;
+  }
+  .klarna-phone-mockup {
+    width: 220px;
+    height: 400px;
+  }
+}

--- a/sections/klarna-hero.liquid
+++ b/sections/klarna-hero.liquid
@@ -1,0 +1,73 @@
+{%- comment -%}
+===========================================
+KLARNA HERO SECTION
+File: sections/klarna-hero.liquid
+Gradient background + split layout + phone mockup
+===========================================
+{%- endcomment -%}
+
+<section class="klarna-hero" data-klarna-hero data-parallax="{{ section.settings.enable_parallax }}" style="--section-padding-top: {{ section.settings.section_padding_top }}px; --section-padding-bottom: {{ section.settings.section_padding_bottom }}px;">
+  <div class="klarna-hero-container klarna-animate">
+    <div class="klarna-hero-content">
+      {%- if section.settings.hero_title != blank -%}
+        <h1>{{ section.settings.hero_title | escape }}</h1>
+      {%- endif -%}
+
+      {%- if section.settings.show_rating -%}
+        <div class="klarna-app-rating">
+          <span class="klarna-stars">{{ section.settings.rating_text }}</span>
+        </div>
+      {%- endif -%}
+
+      {%- if section.settings.hero_subtitle != blank -%}
+        <p class="klarna-hero-text">{{ section.settings.hero_subtitle }}</p>
+      {%- endif -%}
+
+      {%- if section.settings.cta_url != blank -%}
+        <a href="{{ section.settings.cta_url }}" class="klarna-cta-btn klarna-btn klarna-btn-primary">{{ section.settings.cta_text }}</a>
+      {%- endif -%}
+    </div>
+    {%- if section.settings.show_phone_mockup -%}
+    <div class="klarna-hero-phone klarna-animate">
+      <div class="klarna-phone-mockup">
+        <div class="klarna-phone-screen">
+          <div style="margin-bottom: 20px;">📱</div>
+          <div style="text-align: center;">
+            <div style="margin-bottom: 10px;">{{ section.settings.phone_option_1 }}</div>
+            <div style="margin-bottom: 10px;">{{ section.settings.phone_option_2 }}</div>
+            <div style="margin-bottom: 10px;">{{ section.settings.phone_option_3 }}</div>
+            <div>{{ section.settings.phone_option_4 }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    {%- endif -%}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Klarna Hero",
+  "tag": "section",
+  "class": "klarna-hero-section",
+  "settings": [
+    {"type": "text", "id": "hero_title", "label": "Titolo", "default": "Paga a modo tuo con Klarna"},
+    {"type": "textarea", "id": "hero_subtitle", "label": "Sottotitolo", "default": "Acquista in sicurezza e scegli come pagare: oggi, tra 30 giorni, in 3 rate senza interessi, o nel tempo."},
+    {"type": "checkbox", "id": "show_rating", "label": "Mostra rating", "default": true},
+    {"type": "text", "id": "rating_text", "label": "Testo rating", "default": "★ 4.3/5 sull'App Store"},
+    {"type": "text", "id": "cta_text", "label": "Testo bottone", "default": "Scopri di più"},
+    {"type": "url", "id": "cta_url", "label": "URL bottone"},
+    {"type": "checkbox", "id": "show_phone_mockup", "label": "Mostra phone mockup", "default": true},
+    {"type": "text", "id": "phone_option_1", "label": "Opzione 1", "default": "💳 Paga ora"},
+    {"type": "text", "id": "phone_option_2", "label": "Opzione 2", "default": "📅 Paga in 3 rate senza interessi"},
+    {"type": "text", "id": "phone_option_3", "label": "Opzione 3", "default": "⏰ Paga dopo 30 giorni"},
+    {"type": "text", "id": "phone_option_4", "label": "Opzione 4", "default": "💰 Finanziamento"},
+    {"type": "checkbox", "id": "enable_parallax", "label": "Abilita parallax", "default": true},
+    {"type": "range", "id": "section_padding_top", "min": 0, "max": 100, "step": 1, "unit": "px", "label": "Padding top", "default": 64},
+    {"type": "range", "id": "section_padding_bottom", "min": 0, "max": 100, "step": 1, "unit": "px", "label": "Padding bottom", "default": 64}
+  ],
+  "presets": [
+    {"name": "Klarna Hero"}
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add Klarna hero section as a Shopify liquid section
- add hero specific CSS for layout and animation
- add JS for intersection observer and parallax

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851009debd0832090cb9fcd503e1eb9