### PR TITLE
Add klarna footer liquid section

### DIFF
--- a/css/klarna-footer.css
+++ b/css/klarna-footer.css
@@ -1,0 +1,53 @@
+/* KLARNA FOOTER - CSS SPECIFICO */
+.klarna-footer {
+  background: var(--klarna-dark);
+  color: var(--klarna-white);
+  padding: var(--space-2xl) 0;
+}
+.klarna-footer-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--space-lg);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-xl);
+}
+.klarna-footer-section h4 {
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--space-lg);
+  color: var(--klarna-white);
+}
+.klarna-footer-section a {
+  color: #9CA3AF;
+  text-decoration: none;
+  display: block;
+  margin-bottom: var(--space-sm);
+  transition: color 0.2s ease;
+}
+.klarna-footer-section a:hover,
+.klarna-footer-section a:focus {
+  color: var(--klarna-white);
+  outline: none;
+}
+.klarna-footer-bottom {
+  margin-top: var(--space-2xl);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  grid-column: 1 / -1;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+}
+.klarna-footer-logo img {
+  width: 120px;
+  height: auto;
+}
+@media (max-width: 768px) {
+  .klarna-footer-container {
+    grid-template-columns: repeat(var(--mobile-columns, 1), 1fr);
+  }
+  .klarna-footer-bottom {
+    flex-direction: column;
+    text-align: center;
+  }
+}

--- a/js/klarna-footer.js
+++ b/js/klarna-footer.js
@@ -1,0 +1,3 @@
+// KLARNA FOOTER - JAVASCRIPT (se necessario)
+// Currently no interactive behavior is required for the footer.
+// This file is included for future enhancements.

--- a/sections/klarna-footer.liquid
+++ b/sections/klarna-footer.liquid
@@ -1,0 +1,111 @@
+{%- comment -%}
+KLARNA FOOTER SECTION
+File: sections/klarna-footer.liquid
+5-column footer + dark background + link lists
+{%- endcomment -%}
+
+{% liquid
+{{ "klarna-footer.css" | asset_url | stylesheet_tag }}
+{{ "klarna-footer.js" | asset_url | script_tag }}
+  assign mobile_cols = section.settings.columns_per_row_mobile
+%}
+
+<footer class="klarna-footer" role="contentinfo">
+  <nav class="klarna-footer-container" aria-label="Footer" style="--mobile-columns:{{ mobile_cols }}">
+    <div class="klarna-footer-section">
+      {% if section.settings.column_1_title != blank %}
+        <h4>{{ section.settings.column_1_title | escape }}</h4>
+      {% endif %}
+      {% for link in linklists[section.settings.column_1_links].links %}
+        <a href="{{ link.url }}">{{ link.title }}</a>
+      {% endfor %}
+    </div>
+    <div class="klarna-footer-section">
+      {% if section.settings.column_2_title != blank %}
+        <h4>{{ section.settings.column_2_title | escape }}</h4>
+      {% endif %}
+      {% for link in linklists[section.settings.column_2_links].links %}
+        <a href="{{ link.url }}">{{ link.title }}</a>
+      {% endfor %}
+    </div>
+    <div class="klarna-footer-section">
+      {% if section.settings.column_3_title != blank %}
+        <h4>{{ section.settings.column_3_title | escape }}</h4>
+      {% endif %}
+      {% for link in linklists[section.settings.column_3_links].links %}
+        <a href="{{ link.url }}">{{ link.title }}</a>
+      {% endfor %}
+      {% if shop.privacy_policy %}
+        <a href="{{ shop.privacy_policy.url }}">{{ shop.privacy_policy.title }}</a>
+      {% endif %}
+      {% if shop.terms_of_service %}
+        <a href="{{ shop.terms_of_service.url }}">{{ shop.terms_of_service.title }}</a>
+      {% endif %}
+      {% if shop.shipping_policy %}
+        <a href="{{ shop.shipping_policy.url }}">{{ shop.shipping_policy.title }}</a>
+      {% endif %}
+      {% if shop.refund_policy %}
+        <a href="{{ shop.refund_policy.url }}">{{ shop.refund_policy.title }}</a>
+      {% endif %}
+    </div>
+    <div class="klarna-footer-section">
+      {% if section.settings.column_4_title != blank %}
+        <h4>{{ section.settings.column_4_title | escape }}</h4>
+      {% endif %}
+      {% for link in linklists[section.settings.column_4_links].links %}
+        <a href="{{ link.url }}">{{ link.title }}</a>
+      {% endfor %}
+    </div>
+    <div class="klarna-footer-section">
+      {% if section.settings.column_5_title != blank %}
+        <h4>{{ section.settings.column_5_title | escape }}</h4>
+      {% endif %}
+      {% for link in linklists[section.settings.column_5_links].links %}
+        <a href="{{ link.url }}">{{ link.title }}</a>
+      {% endfor %}
+    </div>
+
+    <div class="klarna-footer-bottom">
+      {% if section.settings.show_logo and section.settings.footer_logo != blank %}
+        <div class="klarna-footer-logo">
+          {{ section.settings.footer_logo | image_url: width: 160 | image_tag: loading: 'lazy', alt: section.settings.footer_logo.alt | escape }}
+        </div>
+      {% endif %}
+      {% if section.settings.show_copyright %}
+        <div class="klarna-footer-copy">
+          {% assign year = 'now' | date: '%Y' %}
+          {{ section.settings.copyright_text | replace: '2024', year }}
+        </div>
+      {% endif %}
+    </div>
+  </nav>
+</footer>
+
+
+{% schema %}
+{
+  "name": "Klarna Footer",
+  "tag": "section",
+  "class": "klarna-footer-section",
+  "settings": [
+    {"type": "text", "id": "column_1_title", "default": "Mercato", "label": "Column 1 Title"},
+    {"type": "link_list", "id": "column_1_links", "label": "Column 1 Links"},
+    {"type": "text", "id": "column_2_title", "default": "Klarna", "label": "Column 2 Title"},
+    {"type": "link_list", "id": "column_2_links", "label": "Column 2 Links"},
+    {"type": "text", "id": "column_3_title", "default": "Clienti", "label": "Column 3 Title"},
+    {"type": "link_list", "id": "column_3_links", "label": "Column 3 Links"},
+    {"type": "text", "id": "column_4_title", "default": "Business", "label": "Column 4 Title"},
+    {"type": "link_list", "id": "column_4_links", "label": "Column 4 Links"},
+    {"type": "text", "id": "column_5_title", "default": "Segui", "label": "Column 5 Title"},
+    {"type": "link_list", "id": "column_5_links", "label": "Column 5 Links"},
+    {"type": "checkbox", "id": "show_logo", "default": false, "label": "Show Logo"},
+    {"type": "image_picker", "id": "footer_logo", "label": "Footer Logo"},
+    {"type": "text", "id": "copyright_text", "default": "© 2024 Klarna. Tutti i diritti riservati.", "label": "Copyright"},
+    {"type": "checkbox", "id": "show_copyright", "default": true, "label": "Show Copyright"},
+    {"type": "range", "id": "columns_per_row_mobile", "min": 1, "max": 2, "default": 1, "label": "Columns per row on mobile"}
+  ],
+  "presets": [
+    {"name": "Klarna Footer"}
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- add new liquid section for Klarna footer
- split CSS and JS assets for clarity

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685101a14f5c8320be4ef16c2adc8ba8