### PR TITLE
Add Klarna hero section

### DIFF
--- a/assets/klarna-hero.js
+++ b/assets/klarna-hero.js
@@ -1,0 +1,30 @@
+// ===========================================
+// KLARNA HERO - JAVASCRIPT
+// Animazioni, parallax, intersection observer
+// ===========================================
+
+document.addEventListener('DOMContentLoaded', () => {
+  const hero = document.querySelector('.klarna-hero');
+  if (!hero) return;
+
+  const observer = new IntersectionObserver((entries, obs) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        hero.classList.add('klarna-hero-visible');
+        obs.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+
+  observer.observe(hero);
+
+  const parallaxEnabled = hero.dataset.parallax === 'true';
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (parallaxEnabled && !prefersReduced) {
+    window.addEventListener('scroll', () => {
+      const offset = window.pageYOffset * 0.4;
+      hero.style.transform = `translateY(${offset}px)`;
+    }, { passive: true });
+  }
+});

--- a/assets/klarna-sections.css
+++ b/assets/klarna-sections.css
@@ -95,3 +95,120 @@
     display: flex;
   }
 }
+
+/* ===========================================
+   KLARNA HERO - CSS SPECIFICO
+   File: assets/klarna-sections.css
+   Hero gradients, layout, phone mockup
+   =========================================== */
+
+.klarna-hero {
+  background: linear-gradient(135deg, var(--klarna-dark) 0%, #2D1B4E 100%);
+  color: var(--klarna-white);
+  position: relative;
+  overflow: hidden;
+  padding: var(--space-3xl) 0;
+  transform: translateY(40px);
+  opacity: 0;
+  transition: transform var(--duration-700) var(--ease-out), opacity var(--duration-700) var(--ease-out);
+  will-change: transform;
+}
+
+.klarna-hero-visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.klarna-hero-container {
+  max-width: var(--container-max);
+  margin: 0 auto;
+  padding: 0 var(--space-lg);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3xl);
+  align-items: center;
+}
+
+.klarna-hero-content h1 {
+  font-size: clamp(2.5rem, 5vw, 4rem);
+  font-weight: var(--font-weight-extrabold);
+  line-height: 1.1;
+  margin-bottom: var(--space-lg);
+}
+
+.klarna-app-rating {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-lg);
+  font-size: var(--font-size-sm);
+}
+
+.klarna-stars {
+  color: #FCD34D;
+}
+
+.klarna-hero-text {
+  font-size: 1.125rem;
+  line-height: 1.6;
+  margin-bottom: var(--space-xl);
+  opacity: 0.9;
+}
+
+.klarna-cta-btn {
+  background: var(--klarna-white);
+  color: var(--klarna-black);
+  padding: var(--space-md) var(--space-xl);
+  border-radius: var(--radius-xl);
+  text-decoration: none;
+  font-weight: var(--font-weight-semibold);
+  display: inline-block;
+  transition: all var(--duration-200) var(--ease-out);
+}
+
+.klarna-cta-btn:hover,
+.klarna-cta-btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 25px rgba(0,0,0,0.2);
+}
+
+.klarna-hero-phone {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.klarna-phone-mockup {
+  width: 280px;
+  height: 500px;
+  background: linear-gradient(135deg, #374151 0%, #1F2937 100%);
+  border-radius: var(--radius-2xl);
+  border: 3px solid #4B5563;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+}
+
+.klarna-phone-screen {
+  width: 90%;
+  height: 85%;
+  background: var(--klarna-black);
+  border-radius: var(--radius-lg);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  color: var(--klarna-white);
+  font-size: var(--font-size-sm);
+}
+
+@media (max-width: 768px) {
+  .klarna-hero-container {
+    grid-template-columns: 1fr;
+    gap: var(--space-xl);
+    text-align: center;
+  }
+}

--- a/sections/klarna-hero.liquid
+++ b/sections/klarna-hero.liquid
@@ -1,0 +1,79 @@
+{%- comment -%}
+===========================================
+KLARNA HERO SECTION
+File: sections/klarna-hero.liquid
+Gradient background + split layout + phone mockup
+===========================================
+{%- endcomment -%}
+
+{{ 'klarna-sections.css' | asset_url | stylesheet_tag }}
+{{ 'klarna-hero.js' | asset_url | script_tag }}
+
+<section class="klarna-hero" role="region" aria-labelledby="klarna-hero-title" data-parallax="{{ section.settings.enable_parallax }}" style="padding-top: {{ section.settings.section_padding_top }}px; padding-bottom: {{ section.settings.section_padding_bottom }}px;">
+  <div class="klarna-hero-container">
+    <div class="klarna-hero-content">
+      {% if section.settings.hero_title != blank %}
+        <h1 id="klarna-hero-title">{{ section.settings.hero_title | escape }}</h1>
+      {% endif %}
+
+      {% if section.settings.show_rating %}
+        <div class="klarna-app-rating">
+          <span class="klarna-stars">{{ section.settings.rating_text }}</span>
+        </div>
+      {% endif %}
+
+      {% if section.settings.hero_subtitle != blank %}
+        <p class="klarna-hero-text">{{ section.settings.hero_subtitle }}</p>
+      {% endif %}
+
+      {% if section.settings.cta_url != blank %}
+        <a href="{{ section.settings.cta_url }}" class="klarna-cta-btn">{{ section.settings.cta_text | escape }}</a>
+      {% else %}
+        <span class="klarna-cta-btn">{{ section.settings.cta_text | escape }}</span>
+      {% endif %}
+    </div>
+
+    {% if section.settings.show_phone_mockup %}
+    <div class="klarna-hero-phone">
+      <div class="klarna-phone-mockup">
+        <div class="klarna-phone-screen">
+          <div style="margin-bottom: 20px;">📱</div>
+          <div style="text-align: center;">
+            <div style="margin-bottom: 10px;">{{ section.settings.phone_option_1 }}</div>
+            <div style="margin-bottom: 10px;">{{ section.settings.phone_option_2 }}</div>
+            <div style="margin-bottom: 10px;">{{ section.settings.phone_option_3 }}</div>
+            <div>{{ section.settings.phone_option_4 }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+  </div>
+</section>
+
+{% schema %}
+{
+  "name": "Klarna Hero",
+  "tag": "section",
+  "class": "klarna-hero-section",
+  "settings": [
+    { "type": "text", "id": "hero_title", "label": "Hero title", "default": "Paga a modo tuo con Klarna" },
+    { "type": "textarea", "id": "hero_subtitle", "label": "Hero subtitle", "default": "Acquista in sicurezza e scegli come pagare: oggi, tra 30 giorni, in 3 rate senza interessi, o nel tempo." },
+    { "type": "checkbox", "id": "show_rating", "label": "Show rating", "default": true },
+    { "type": "text", "id": "rating_text", "label": "Rating text", "default": "★ 4.3/5 sull'App Store" },
+    { "type": "text", "id": "cta_text", "label": "CTA text", "default": "Scopri di più" },
+    { "type": "url", "id": "cta_url", "label": "CTA URL" },
+    { "type": "checkbox", "id": "show_phone_mockup", "label": "Show phone mockup", "default": true },
+    { "type": "text", "id": "phone_option_1", "label": "Phone option 1", "default": "💳 Paga ora" },
+    { "type": "text", "id": "phone_option_2", "label": "Phone option 2", "default": "📅 Paga in 3 rate senza interessi" },
+    { "type": "text", "id": "phone_option_3", "label": "Phone option 3", "default": "⏰ Paga dopo 30 giorni" },
+    { "type": "text", "id": "phone_option_4", "label": "Phone option 4", "default": "💰 Finanziamento" },
+    { "type": "checkbox", "id": "enable_parallax", "label": "Enable parallax", "default": true },
+    { "type": "range", "id": "section_padding_top", "label": "Padding top", "min": 0, "max": 100, "default": 64 },
+    { "type": "range", "id": "section_padding_bottom", "label": "Padding bottom", "min": 0, "max": 100, "default": 64 }
+  ],
+  "presets": [
+    { "name": "Klarna Hero" }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- implement hero as Liquid section with customizable schema
- add hero-specific CSS for gradient layout, phone mockup and responsiveness
- implement JS for fade-in and parallax effects

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685102a6c5e08320952019832191b62d